### PR TITLE
Replacing README.adoc with README.md.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,0 @@
-This repo contains Rust code of https://github.com/miracl/core[`miracl_core`] for curve BLS 12-381.
-It was built from https://github.com/miracl/core/commit/938c5e754e8281572831bc28bd589e914118c0a2[938c5e7]
-according to https://github.com/miracl/core/tree/master/rust#using-miracl-core-with-cargo[these instructions],
-running `python3 config64.py` for curve #31 (bls12381).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+This repo contains a subset of [`miracl_core`](https://github.com/miracl/core) for curve BLS 12-381.
+It was built from [commit 938c5e7](https://github.com/miracl/core/commit/938c5e754e8281572831bc28bd589e914118c0a2)
+according to [these instructions](https://github.com/miracl/core/tree/master/rust#using-miracl-core-with-cargo),
+running `python3 config64.py` for curve #31 (bls12381).


### PR DESCRIPTION
It seems that crates.io does not support adoc.