### PR TITLE
feat: compatibility for `ic-agent`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,14 @@
 version = 3
 
 [[package]]
+name = "hex-literal"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
+
+[[package]]
 name = "miracl_core_bls12381"
 version = "4.1.2"
+dependencies = [
+ "hex-literal",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,14 +3,131 @@
 version = 3
 
 [[package]]
+name = "bumpalo"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "hex-literal"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "miracl_core_bls12381"
 version = "4.1.2"
 dependencies = [
  "hex-literal",
+ "wasm-bindgen",
 ]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 include = ["src", "Cargo.toml", "LICENSE", "README.md", "NOTICE.txt"]
 
 [dependencies]
+wasm-bindgen = { version = "0.2.67", optional = true }
 
 [dev-dependencies]
 hex-literal = "0.3.4"
@@ -20,3 +21,13 @@ default = ['std', 'fallback_separator']
 allow_alt_compress = []
 fallback_separator = []
 std = []
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-Oz", "--enable-mutable-globals"]
+
+[profile.release]
+lto = true
+opt-level = 'z'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,11 @@ include = ["src", "Cargo.toml", "LICENSE", "README.md", "NOTICE.txt"]
 
 [dependencies]
 
+[dev-dependencies]
+hex-literal = "0.3.4"
+
 [features]
-default = ['std']
+default = ['std', 'fallback_separator']
+allow_alt_compress = []
+fallback_separator = []
 std = []

--- a/src/bls12381/big.rs
+++ b/src/bls12381/big.rs
@@ -293,7 +293,7 @@ impl BIG {
 
     /* Convert to Hex String */
 //#[cfg(feature = "std")]
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
     pub fn tostring(&self) -> String {
         let mut s = String::new();
         let mut len = self.nbits();

--- a/src/bls12381/bls.rs
+++ b/src/bls12381/bls.rs
@@ -71,7 +71,10 @@ fn hash_to_field(hash: usize,hlen: usize ,u: &mut [FP], dst: &[u8],m: &[u8],ctr:
 /* hash a message to an ECP point, using SHA2, random oracle method */
 #[allow(non_snake_case)]
 pub fn bls_hash_to_point(m: &[u8]) -> ECP {
-    let dst= "BLS_SIG_BLS12381G1_XMD:SHA-256_SVDW_RO_NUL_";
+    #[cfg(not(feature = "fallback_separator"))]
+    let dst = "BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_";
+    #[cfg(feature = "fallback_separator")]
+    let dst = "BLS_SIG_BLS12381G1_XMD:SHA-256_SVDW_RO_NUL_";
 
     let mut u: [FP; 2] = [
         FP::new(),

--- a/src/bls12381/dbig.rs
+++ b/src/bls12381/dbig.rs
@@ -292,7 +292,7 @@ impl DBIG {
     }
 
     /* Convert to Hex String */
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
     pub fn tostring(&self) -> String {
         let mut s = String::new();
         let mut len = self.nbits();

--- a/src/bls12381/ecp.rs
+++ b/src/bls12381/ecp.rs
@@ -505,7 +505,7 @@ impl ECP {
     }
 
     /* convert to hex string */
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
     pub fn tostring(&self) -> String {
         let mut W = ECP::new();
         W.copy(self);

--- a/src/bls12381/ecp.rs
+++ b/src/bls12381/ecp.rs
@@ -68,7 +68,7 @@ pub const G2_TABLE:usize=69;
 pub const HTC_ISO:usize=11;
 pub const HTC_ISO_G2:usize=3;
 
-pub const ALLOW_ALT_COMPRESS:bool=false;
+pub const ALLOW_ALT_COMPRESS:bool=cfg!(feature = "allow_alt_compress");
 pub const HASH_TYPE:usize=32;
 pub const AESKEY:usize=16;
 

--- a/src/bls12381/ecp2.rs
+++ b/src/bls12381/ecp2.rs
@@ -324,7 +324,7 @@ impl ECP2 {
     }
 
     /* convert this to hex string */
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
     pub fn tostring(&self) -> String {
         let mut W = ECP2::new();
         W.copy(self);

--- a/src/bls12381/fp.rs
+++ b/src/bls12381/fp.rs
@@ -209,7 +209,7 @@ impl FP {
     }
 
     /* convert to string */
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
     pub fn tostring(&self) -> String {
         self.redc().tostring()
     }

--- a/src/bls12381/fp12.rs
+++ b/src/bls12381/fp12.rs
@@ -907,7 +907,7 @@ impl FP12 {
     }
 
     /* output to hex string */
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
     pub fn tostring(&self) -> String {
         format!(
             "[{},{},{}]",

--- a/src/bls12381/fp2.rs
+++ b/src/bls12381/fp2.rs
@@ -449,7 +449,7 @@ impl FP2 {
     }
 
     /* output to hex string */
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
     pub fn tostring(&self) -> String {
         format!("[{},{}]", self.a.tostring(), self.b.tostring())
     }

--- a/src/bls12381/fp4.rs
+++ b/src/bls12381/fp4.rs
@@ -388,7 +388,7 @@ impl FP4 {
     }
 
     /* output to hex string */
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
     pub fn tostring(&self) -> String {
         format!("[{},{}]", self.a.tostring(), self.b.tostring())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-//#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 #![allow(clippy::many_single_char_names)]
 #![allow(clippy::needless_range_loop)]
@@ -36,3 +36,18 @@ pub mod sha3;
 pub mod nhs;
 pub mod x509;
 pub mod bls12381;
+
+#[cfg(test)]
+mod tests {
+    #[cfg(all(feature = "allow_alt_compress", not(feature = "fallback_separator")))]
+    #[test]
+    fn bls_verify() {
+        use hex_literal::hex;
+        use crate::bls12381::bls::{core_verify, init, BLS_FAIL, BLS_OK};
+        let pk = hex!("a7623a93cdb56c4d23d99c14216afaab3dfd6d4f9eb3db23d038280b6d5cb2caaee2a19dd92c9df7001dede23bf036bc0f33982dfb41e8fa9b8e96b5dc3e83d55ca4dd146c7eb2e8b6859cb5a5db815db86810b8d12cee1588b5dbf34a4dc9a5");
+        let sig = hex!("b89e13a212c830586eaa9ad53946cd968718ebecc27eda849d9232673dcd4f440e8b5df39bf14a88048c15e16cbcaabe");
+        assert_eq!(init(), BLS_OK);
+        assert_eq!(core_verify(&sig, b"hello".as_ref(), &pk), BLS_OK);
+        assert_eq!(core_verify(&sig, b"hallo".as_ref(), &pk), BLS_FAIL);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@
 #![allow(clippy::needless_range_loop)]
 #![allow(clippy::manual_memcpy)]
 #![allow(clippy::new_without_default)]
+
 pub mod arch;
 pub mod aes;
 pub mod gcm;
@@ -36,6 +37,21 @@ pub mod sha3;
 pub mod nhs;
 pub mod x509;
 pub mod bls12381;
+
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+pub fn bls_init() -> isize {
+    bls12381::bls::init()
+}
+
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+pub fn bls_verify(sig: &[u8], m: &[u8], s: &[u8]) -> isize {
+    bls12381::bls::core_verify(sig, m, s)
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}


### PR DESCRIPTION
Companion to dfinity/agent-js#590

This should now be compatible with agent-rs and agent-js. This includes preparing `Cargo.toml` for `wasm-pack`.

Also fixes-up the `std` feature (e.g. conditionally enable `no_std`).

Adds in the test from `ic-agent` to verify compatibility.